### PR TITLE
javaName på schema for bedre pojo-generering.

### DIFF
--- a/schemas/dpi/innbyggerpost_dpi_aapningskvittering_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_aapningskvittering_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En KvitteringsMelding til Avsender om at Mottaker har åpnet forsendelsen i sin postkasse.",
     "$comment": "Åpningskvitteringer blir bare sendt dersom dette er bestilt av Avsender i digital post meldingen ved å spesifisere dette i digitalpostinfo. Mottaker må aksepteres at det sendes en ÅpningsKvittering til Avsender for å få lest den digital posten. Mangel på ÅpningsKvittering betyr at Mottaker ikke har lest dokumentet.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "AapningsKvitteringSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_digital_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_digital_1_0.schema.json
@@ -7,6 +7,7 @@
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "DigitalPostSDP",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_feil_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_feil_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En feilmelding fra postkasseleverandør med informasjon om en forretningsfeil knyttet til en digital post forsendelse.",
     "$comment": "Feilmelding sendes fra Postkasseleverandør når det oppstår en uventet feil som ikke kan håndteres av postkasseleverandør innenfor SLA krav. Feilene kategoriseres overordnet i to typer, enten som klient feil som Avsender må rette opp i eller som server feil som oppstår hos postkasseleverandør.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "FeilSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_flyttet_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_flyttet_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En digital post med tilhørende Dokumentpakke som flyttes fra en postkasseleverandør til en annen",
     "$comment": "Denne meldingstypen brukes kun imellom Postkasseleverandørene og ikke av Avsender. Den brukes dersom Innbygger velger å flytte sin post over til en annen postkasseleverandør.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "FlytteDigitalPostSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_leveringskvittering_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_leveringskvittering_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Kvittering på at postkassen eller utskriftstjenesten har tatt ansvar for å tilgjengeliggjøre melding til mottaker. Sendes til Avsender via meldingsformideler.",
     "$comment": "Denne kvitteringen kan Behandlingsansvarlig oppbevare som en garanti på at posten vil bli levert til Mottaker.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "LeveringsKvitteringSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_mottakskvittering_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_mottakskvittering_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at utskrift og forsendelsestjenesten har mottatt forsendelsen og har lagt den klar for utskrift.",
     "$comment": "Denne Kvitteringen leveres tilbake så fort utskrift og forsendelsestjenesten har mottatt forsendelsen og validert at den kan skrives ut. Forsendelsen vil så legges i kø og tas med i neste utskriftsjobb for denne type post.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "MottaksKvitteringSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_returpostkvittering_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_returpostkvittering_1_0.schema.json
@@ -3,11 +3,13 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding fra Utskriftstjenesten til Avsender om at post ikke kunne leveres til Mottaker.",
     "$comment": "Dette er Kvittering på at posten har kommet i retur og har blitt makulert.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "ReturpostKvitteringSBD",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_utskrift_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_utskrift_1_0.schema.json
@@ -7,6 +7,7 @@
             "type": "object",
             "additionalProperties": false,
             "title": "standardBusinessDocument",
+            "javaName": "UtskriftSDP",
             "properties": {
                 "standardBusinessDocumentHeader": {
                     "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"

--- a/schemas/dpi/innbyggerpost_dpi_varslingfeiletkvittering_1_0.schema.json
+++ b/schemas/dpi/innbyggerpost_dpi_varslingfeiletkvittering_1_0.schema.json
@@ -3,10 +3,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at varsling til Mottaker har feilet og dermed ikke har blitt utført som forutsatt.",
     "$comment": "Dersom Postkasse opplever problemer med å utføre varslingen som spesifisert i meldingen, skal Postkasse informere Avsender om dette ved å sende VarslingfeiletKvittering. Det skal sendes en kvittering for hver forekomst av en feilsituasjon i en spesifisert kanal. Meldinger som angir bruk av flere varslingskanaler kan dermed medføre flere VarslingfeiletKvitteringer. Varslingfeilet kvittering skal sendes seinest dagen etter at varslingen var bestilt.",
+    "javaInterfaces" : ["no.digdir.dpi.domain.Kvittering10Schema"],
     "definitions": {
         "standardBusinessDocument": {
             "type": "object",
             "additionalProperties": false,
+            "javaName": "VarslingFeiletKvitteringSBD",
             "title": "standardBusinessDocument",
             "properties": {
                 "standardBusinessDocumentHeader": {


### PR DESCRIPTION
Lager en draf PR for synlighet om at denne branchen benyttes (slik at den ikke blir slettet in the wild).

Legger til javaName på alle SBD-er slik at pojo-generering med jsonschema2pojo gir finere klassenavn. Optimalt hadde dette lugget utenfor schema (i en bindings-fil), men ser ikke ut som det er støttet. Derfor må dette proprietær feltet inn i schema..

Workflow ved oppdatering av https://github.com/difi/felleslosninger
1. Fetch upstream (dvs ta inn endringene fra difi/felleslosninger inn i dette repoet)
2. Merge gh-pages inn i denne branchen (her kun man jo brukt rebase, men gikk for merge for synligheten og historikken sin skyld)
3. Done. Du kan nå oppdater git submodulen i prosjektet ditt
